### PR TITLE
Update StreamConnection.cs

### DIFF
--- a/Data Collector/Stream Connection/C#/StreamConnection.cs
+++ b/Data Collector/Stream Connection/C#/StreamConnection.cs
@@ -13,64 +13,78 @@ using System.Collections.Generic;
 using System.Linq;
 
 namespace StreamConnection
-
 {
     class Program
     {
         public static void Main(string[] args)
         {
+            AddToConsole("Starting...");
 
-            Console.WriteLine("Starting...");
+            string urlString = "YOUR_STREAM_URL_HERE";
 
-            string urlString ="YOUR_STREAM_URL_HERE";
-
-            HttpWebRequest request = (System.Net.HttpWebRequest)WebRequest.Create(urlString);
+            HttpWebRequest request = (HttpWebRequest)WebRequest.Create(urlString);
             request.Method = "GET";
 
             //Setup Credentials.
             string username = "YOUR_USERNAME_HERE";
             string password = "YOUR_PASSWORD_HERE";
 
-            //Authentication details.
-            NetworkCredential nc = new NetworkCredential(username, password);
-            request.Credentials = nc;
-            request.PreAuthenticate = true;
+            // Authentication
+            string authInfo = string.Format("{0}:{1}", username, password);
+            authInfo = Convert.ToBase64String(Encoding.Default.GetBytes(authInfo));
+            request.Headers.Add("Authorization", "Basic " + authInfo);
 
-            request.Timeout = 35;
-            AsyncCallback asyncCallback = new AsyncCallback(handleResult);    //Setting handleResult as Callback method...
-            request.BeginGetResponse(asyncCallback, request);    //Calling BeginGetResponse on request...
+            request.Headers.Add("Accept-Encoding", "gzip");
+            request.Accept = "application/json";
+            request.ContentType = "application/json";
+            request.UserAgent = "Your Agent/Product Name";  // This setting is optional
 
-            Console.WriteLine("Main thread sleeping...");
+            request.Timeout = 35; //GNIP sends 15 second heartbeats
+
+            AsyncCallback asyncCallback = new AsyncCallback(handleResult);  //Setting handleResult as Callback method...
+
+            try
+            {
+                request.BeginGetResponse(asyncCallback, request);   //Calling BeginGetResponse on request...
+            }
+            catch (WebException ex)
+            {
+                AddToConsole("CONNECTION EXCEPTION - " + ex.Message + Environment.NewLine);
+                request.Abort();
+                // Do whatever you need to do here e.g. re-connect, re-start etc.
+                return;
+            }
+            catch (Exception ex)
+            {
+                AddToConsole("EXCEPTION - " + ex.Message + Environment.NewLine);
+                // Do whatever you need to do, do here e.g. re-connect, re-start etc.
+                return;
+            }
+
+            AddToConsole("Main thread sleeping...");
+
             while (true)
             {
                 System.Threading.Thread.Sleep(1000);
             }
-            
         }
 
         static void handleResult(IAsyncResult result)
         {
-
             //string outputFile = @"C:\dev\csharp\Stream_Data.txt";     //Uncomment and update if you want to write to a local file.
             HttpWebRequest request = (HttpWebRequest)result.AsyncState;
 
             using (HttpWebResponse response = (HttpWebResponse)request.EndGetResponse(result))
             using (Stream stream = response.GetResponseStream())
             using (MemoryStream memory = new MemoryStream())
-
             {
                 byte[] compressedBuffer = new byte[8192];
                 byte[] uncompressedBuffer = new byte[8192];
                 List<byte> output = new List<byte>();
 
-                if (!stream.CanRead)
-                {
-                    Console.WriteLine(" --- Cannot Read Stream");
-                }
-
                 while (stream.CanRead)
                 {
-                    Console.WriteLine(" +++ Reading Stream");
+                    AddToConsole(" +++ Reading Stream");
 
                     try
                     {
@@ -83,41 +97,55 @@ namespace StreamConnection
 
                         output.AddRange(uncompressedBuffer.Take(uncompressedLength));
 
-                        if (!output.Contains(0x0A)) continue;  //Heartbeat
-
                         byte[] bytesToDecode = output.Take(output.LastIndexOf(0x0A) + 1).ToArray();
                         string outputString = Encoding.UTF8.GetString(bytesToDecode);
                         output.RemoveRange(0, bytesToDecode.Length);
 
                         string[] lines = outputString.Split(new[] { Environment.NewLine }, new StringSplitOptions());
+
                         for (int i = 0; i < (lines.Length - 1); i++)
                         {
                             string heartBeatCheck = lines[i];
                             if (heartBeatCheck.Trim().Length > 0)
                             {
-                                Console.WriteLine(lines[i]);  //Just echo out line onto terminal...
+                                AddToConsole(lines[i]);  //Just print out to console window...
                                 //File.AppendAllText(outputFile, lines[i] + Environment.NewLine); //Write out to the file...
                             }
                             else
                             {
-                                Console.WriteLine(" *** Heartbeat Received");
+                                AddToConsole(" ♥♥♥ Heartbeat Received");
                             }
                         }
                     }
                     catch (Exception error)
                     {
-                        Console.WriteLine(error.Message);
+                        AddToConsole(error.Message);
+                        // Handle the error as needed here
                     }
-                    memory.SetLength(0);
+
+                    memory.SetLength(0);    // Everything needs to reach this line otherwise you will end up with 
+                                            // merged activities and loads of errors. i.e. do not use "return", "continue" etc. 
+                                            // above this line without setting the memory length to ZERO first.
                 }
 
                 if (!stream.CanRead)
                 {
-                    Console.WriteLine(" --- Cannot Read Stream");
+                    AddToConsole(" --- Cannot Read Stream");
+                    // Handle the situation as needed here. The stream is probably corrupted.
                 }
             }
-
         }
 
+        static string TStamp()
+        {
+            DateTime dt = DateTime.Now;
+
+            return dt.ToShortDateString() + " " + dt.ToLongTimeString() + ": ";
+        }
+
+        private void AddToConsole(string text)
+        {
+            Console.WriteLine(TStamp() + text + Environment.NewLine);
+        }
     }
 }


### PR DESCRIPTION
Up to 10% of received activities were being lost. The main culprit behind it was line 86:

if (!output.Contains(0x0A)) continue;  //Heartbeat

Which was skipping iteration without clearing the allocated memory hence causing memory in different threads to clash and merge in part or whole.

I have also added some other parts to make it a good commercial base for those starting out on PowerTrack. I hope it will be of benefit to GNIP and its customers.

Mustafa Ozkececigil/Fluxifi
