### PR TITLE
Fix Gzip decompresstion error

### DIFF
--- a/Premium Stream Connection/C#/StreamingConnection_Async.cs
+++ b/Premium Stream Connection/C#/StreamingConnection_Async.cs
@@ -105,7 +105,6 @@ namespace StreamingConnection
             using (HttpWebResponse response = (HttpWebResponse)request.EndGetResponse(result))
             using (Stream stream = response.GetResponseStream())
             using (MemoryStream memory = new MemoryStream())
-            using (GZipStream gzip = new GZipStream(memory, CompressionMode.Decompress))
             {
                 byte[] compressedBuffer = new byte[8192];
                 byte[] uncompressedBuffer = new byte[8192];
@@ -127,9 +126,11 @@ namespace StreamingConnection
                         memory.Write(compressedBuffer.Take(readCount).ToArray(), 0, readCount);
                         memory.Position = 0;
 
-                        int uncompressedLength = gzip.Read(uncompressedBuffer, 0, uncompressedBuffer.Length);
-
-                        output.AddRange(uncompressedBuffer.Take(uncompressedLength));
+                        // No need to decompress the stream again because request.AutomaticDecompression is enabled so the stream will be automatically decompressed
+                        //(see line 80)
+                        //int uncompressedLength = gzip.Read(uncompressedBuffer, 0, uncompressedBuffer.Length);
+                        uncompressedBuffer = memory.ToArray();
+                        output.AddRange(uncompressedBuffer.Take(uncompressedBuffer.Length));
 
                         if (!output.Contains(0x0A)) continue;  //Heartbeat
 


### PR DESCRIPTION
as per  my recently reported problem, the async code will fail when trying to decompress the stream.

after a few investigations, the reason behind this fail is because the request object is already utilizing the `AutomaticDecompression` feature, so the stream inside the `handleResult` method is automatically decompressed using Gzip and no longer needs decompression.

I've fixed this issue and asking you to kindly accept this pull request.

Thank you,
Mohammed