### PR TITLE
Update CreateHistoricalJob.php - added CURLOPT_RETURNTRANSFER=true

### DIFF
--- a/Historical PowerTrack/PHP/CreateHistoricalJob.php
+++ b/Historical PowerTrack/PHP/CreateHistoricalJob.php
@@ -24,6 +24,7 @@ curl_setopt_array($ch, array(
   CURLOPT_HTTPAUTH => CURLAUTH_BASIC,
   CURLOPT_USERPWD => $user.":".$pass,
   CURLOPT_POST    => 1,
+  CURLOPT_RETURNTRANSFER => true,
   CURLOPT_POSTFIELDS => $jobString,
 //  CURLOPT_VERBOSE => true  // Uncomment for curl verbosity
 ));


### PR DESCRIPTION
Added CURLOPT_RETURNTRANSFER=true as $content was returning 1 instead of the return body.
