### PR TITLE
python3 historical powertrack downloader

### DIFF
--- a/Historical PowerTrack/Python/downloader/README.md
+++ b/Historical PowerTrack/Python/downloader/README.md
@@ -1,0 +1,13 @@
+# Python3 Downloader for historical powertrack files.
+
+Contributed by Brian Ballsun-Stanton, Macquarie University
+MIT License.
+
+Use pyenv or other virtual environment if possible.
+
+Make sure your results.json is in `input/``
+
+```
+$ pip install -r requirements.txt
+$ python3 downloadHistoricalPowertrack.py
+```

--- a/Historical PowerTrack/Python/downloader/downloadHistoricalPowertrack.py
+++ b/Historical PowerTrack/Python/downloader/downloadHistoricalPowertrack.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+# By Brian Ballsun-Stanton, Macquarie Uni
+# MIT License
+
+# Designed to replace the PTDownloader GNIP package https://github.com/gnip/support
+
+
+import json
+from pprint import pprint
+import tqdm
+import os
+import re
+import requests
+
+DIRECTORY="downloads"
+
+with open("input/results.json") as jsonfile:
+	to_download = json.load(jsonfile)
+
+tqdm_wrapper = tqdm.tqdm(to_download['urlList'])
+for line in tqdm_wrapper:
+	url_split = re.split(r"/|\?", line)
+	filename = f"{DIRECTORY}/{'_'.join(url_split[12:-1])}"
+	try:
+		with open(filename) as to_write_file:
+			tqdm_wrapper.write(f"{filename} already exists, skipping...")
+			pass
+	except IOError:
+		with open(filename, "wb") as to_write_file:
+			r = requests.get(line)
+			to_write_file.write(r.content)

--- a/Historical PowerTrack/Python/downloader/requirements.txt
+++ b/Historical PowerTrack/Python/downloader/requirements.txt
@@ -1,0 +1,6 @@
+certifi==2020.12.5
+chardet==4.0.0
+idna==2.10
+requests==2.25.1
+tqdm==4.60.0
+urllib3==1.26.4


### PR DESCRIPTION
Since the shell script is throwing increasing errors, here's a python3 downloader for one-off historical powertrack jobs. Organise as you see fit.